### PR TITLE
feat: allow password to be taken from pipe

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"syscall"
 
 	"github.com/passbolt/go-passbolt-cli/util"
 	"github.com/passbolt/go-passbolt/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"golang.org/x/term"
 )
 
 // verifyCMD represents the verify command
@@ -35,12 +33,12 @@ var verifyCMD = &cobra.Command{
 		userPassword := viper.GetString("userPassword")
 		if userPassword == "" {
 			fmt.Print("Enter Password:")
-			bytepw, err := term.ReadPassword(int(syscall.Stdin))
+			pw, err := util.ReadPassword()
 			if err != nil {
 				fmt.Println()
 				return fmt.Errorf("Reading Password: %w", err)
 			}
-			userPassword = string(bytepw)
+			userPassword = pw
 			fmt.Println()
 		}
 

--- a/keepass/export.go
+++ b/keepass/export.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"syscall"
 
 	"github.com/passbolt/go-passbolt-cli/util"
 	"github.com/passbolt/go-passbolt/api"
@@ -13,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tobischo/gokeepasslib/v3"
 	w "github.com/tobischo/gokeepasslib/v3/wrappers"
-	"golang.org/x/term"
 )
 
 // KeepassExportCmd Exports a Passbolt Keepass
@@ -56,12 +54,12 @@ func KeepassExport(cmd *cobra.Command, args []string) error {
 
 	if keepassPassword == "" {
 		fmt.Print("Enter Keepass Password:")
-		bytepw, err := term.ReadPassword(int(syscall.Stdin))
+		pw, err := util.ReadPassword()
 		if err != nil {
 			fmt.Println()
 			return fmt.Errorf("Reading Keepass Password: %w", err)
 		}
-		keepassPassword = string(bytepw)
+		keepassPassword = pw
 		fmt.Println()
 	}
 

--- a/util/client.go
+++ b/util/client.go
@@ -17,7 +17,8 @@ import (
 	"golang.org/x/term"
 )
 
-func readPassword() (string, error) {
+// ReadPassword reads a Password interactively or via Pipe
+func ReadPassword() (string, error) {
 	var fd int
 	var pass []byte
 	if term.IsTerminal(syscall.Stdin) {
@@ -55,7 +56,7 @@ func GetClient(ctx context.Context) (*api.Client, error) {
 
 	userPassword := viper.GetString("userPassword")
 	if userPassword == "" {
-		cliPassword, err := readPassword()
+		cliPassword, err := ReadPassword()
 		if err != nil {
 			fmt.Println()
 			return nil, fmt.Errorf("Reading Password: %w", err)

--- a/util/client.go
+++ b/util/client.go
@@ -97,12 +97,11 @@ func GetClient(ctx context.Context) (*api.Client, error) {
 			for i := 0; i < 3; i++ {
 				var code string
 				fmt.Print("Enter TOTP:")
-				bytepw, err := term.ReadPassword(int(syscall.Stdin))
+				code, err := ReadPassword()
 				if err != nil {
 					fmt.Printf("\n")
 					return http.Cookie{}, fmt.Errorf("Reading TOTP: %w", err)
 				}
-				code = string(bytepw)
 				fmt.Printf("\n")
 				req := api.MFAChallangeResponse{
 					TOTP: code,

--- a/util/client.go
+++ b/util/client.go
@@ -14,18 +14,17 @@ import (
 	"github.com/passbolt/go-passbolt/api"
 	"github.com/passbolt/go-passbolt/helper"
 	"github.com/spf13/viper"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/term"
 )
 
 func readPassword() (string, error) {
 	var fd int
 	var pass []byte
-	if terminal.IsTerminal(syscall.Stdin) {
+	if term.IsTerminal(syscall.Stdin) {
 		fmt.Print("Enter Password:")
 
 		fd = syscall.Stdin
-		inputPass, err := terminal.ReadPassword(fd)
+		inputPass, err := term.ReadPassword(fd)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Hello, 

This change allows to give the password from another command, via a bash pipe.
The needs is to get the password from the local vault to prevent to have the password stored in clear on the disk.

For exemple, on macOS with Keychain.

```
# Find a password name "passbolt" in keychain and pass it to go-passbolt-cli
security find-generic-password -w -a 'passbolt' | go-passbolt-cli get user
```
Of course, the go-passbolt-cli does not know the password and is configured to ask it each time.

Thank you for your work!
Have a nice day

