### PR TITLE
Added support for http client configuration via command arguments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,10 @@ func init() {
 	rootCmd.PersistentFlags().Uint("mfaRetrys", 3, "How often to retry TOTP Auth, only used in nointeractive modes")
 	rootCmd.PersistentFlags().Duration("mfaDelay", time.Second*10, "Delay between MFA Attempts, only used in noninteractive modes")
 
+	rootCmd.PersistentFlags().Bool("tlsSkipVerify", false, "Allow servers with self-signed certificates")
+	rootCmd.PersistentFlags().String("tlsClientPrivateKey", "", "Client private key for mtls")
+	rootCmd.PersistentFlags().String("tlsClientCert", "", "Client certificate for mtls")
+
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))
 	viper.BindPFlag("serverAddress", rootCmd.PersistentFlags().Lookup("serverAddress"))
@@ -72,6 +76,10 @@ func init() {
 	viper.BindPFlag("mfaTotpOffset", rootCmd.PersistentFlags().Lookup("mfaTotpOffset"))
 	viper.BindPFlag("mfaRetrys", rootCmd.PersistentFlags().Lookup("mfaRetrys"))
 	viper.BindPFlag("mfaDelay", rootCmd.PersistentFlags().Lookup("mfaDelay"))
+
+	viper.BindPFlag("tlsSkipVerify", rootCmd.PersistentFlags().Lookup("tlsSkipVerify"))
+	viper.BindPFlag("tlsClientCert", rootCmd.PersistentFlags().Lookup("tlsClientCert"))
+	viper.BindPFlag("tlsClientPrivateKey", rootCmd.PersistentFlags().Lookup("tlsClientPrivateKey"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -61,8 +60,10 @@ func init() {
 	rootCmd.PersistentFlags().Duration("mfaDelay", time.Second*10, "Delay between MFA Attempts, only used in noninteractive modes")
 
 	rootCmd.PersistentFlags().Bool("tlsSkipVerify", false, "Allow servers with self-signed certificates")
-	rootCmd.PersistentFlags().String("tlsClientPrivateKeyFile", "", "Client private key for mtls")
-	rootCmd.PersistentFlags().String("tlsClientCertFile", "", "Client certificate for mtls")
+	rootCmd.PersistentFlags().String("tlsClientPrivateKeyFile", "", "Client private key path for mtls")
+	rootCmd.PersistentFlags().String("tlsClientCertFile", "", "Client certificate path for mtls")
+	rootCmd.PersistentFlags().String("tlsClientPrivateKey", "", "Client private key for mtls")
+	rootCmd.PersistentFlags().String("tlsClientCert", "", "Client certificate for mtls")
 
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))
@@ -80,6 +81,18 @@ func init() {
 	viper.BindPFlag("tlsSkipVerify", rootCmd.PersistentFlags().Lookup("tlsSkipVerify"))
 	viper.BindPFlag("tlsClientCert", rootCmd.PersistentFlags().Lookup("tlsClientCert"))
 	viper.BindPFlag("tlsClientPrivateKey", rootCmd.PersistentFlags().Lookup("tlsClientPrivateKey"))
+}
+
+func fileToContent(file, contentFlag string) {
+	if viper.GetBool("debug") {
+		fmt.Fprintln(os.Stderr, "Loading file:", file)
+	}
+	content, err := os.ReadFile(file)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error Loading File: ", err)
+		os.Exit(1)
+	}
+	viper.Set(contentFlag, string(content))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -115,17 +128,25 @@ func initConfig() {
 	// Read in Private Key from File if userprivatekeyfile is set
 	userprivatekeyfile, err := rootCmd.PersistentFlags().GetString("userPrivateKeyFile")
 	if err == nil && userprivatekeyfile != "" {
-		if viper.GetBool("debug") {
-			fmt.Fprintln(os.Stderr, "Loading Private Key from File:", userprivatekeyfile)
-		}
-		content, err := ioutil.ReadFile(userprivatekeyfile)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Error Loading Private Key from File: ", err)
-			os.Exit(1)
-		}
-		viper.Set("userprivatekey", string(content))
+		fileToContent(userprivatekeyfile, "userPrivateKey")
 	} else if err != nil && viper.GetBool("debug") {
 		fmt.Fprintln(os.Stderr, "Getting Private Key File Flag:", err)
+	}
+
+	// Read in Client Certificate Private Key from File if tlsClientPrivateKeyFile is set
+	tlsclientprivatekeyfile, err := rootCmd.PersistentFlags().GetString("tlsClientPrivateKeyFile")
+	if err == nil && tlsclientprivatekeyfile != "" {
+		fileToContent(tlsclientprivatekeyfile, "tlsClientPrivateKey")
+	} else if err != nil && viper.GetBool("debug") {
+		fmt.Fprintln(os.Stderr, "Getting Client Certificate Private key File Flag:", err)
+	}
+
+	// Read in Client Certificate from File if tlsClientCertFile is set
+	tlsclientcertfile, err := rootCmd.PersistentFlags().GetString("tlsClientCertFile")
+	if err == nil && tlsclientcertfile != "" {
+		fileToContent(tlsclientcertfile, "tlsClientCert")
+	} else if err != nil && viper.GetBool("debug") {
+		fmt.Fprintln(os.Stderr, "Getting Client Certificate File Flag:", err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,8 +61,8 @@ func init() {
 	rootCmd.PersistentFlags().Duration("mfaDelay", time.Second*10, "Delay between MFA Attempts, only used in noninteractive modes")
 
 	rootCmd.PersistentFlags().Bool("tlsSkipVerify", false, "Allow servers with self-signed certificates")
-	rootCmd.PersistentFlags().String("tlsClientPrivateKey", "", "Client private key for mtls")
-	rootCmd.PersistentFlags().String("tlsClientCert", "", "Client certificate for mtls")
+	rootCmd.PersistentFlags().String("tlsClientPrivateKeyFile", "", "Client private key for mtls")
+	rootCmd.PersistentFlags().String("tlsClientCertFile", "", "Client certificate for mtls")
 
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -41,7 +41,11 @@ var verifyCMD = &cobra.Command{
 			fmt.Println()
 		}
 
-		client, err := api.NewClient(nil, "", serverAddress, userPrivateKey, userPassword)
+		httpClient, err := util.GetHttpClient()
+		if err != nil {
+			return err
+		}
+		client, err := api.NewClient(httpClient, "", serverAddress, userPrivateKey, userPassword)
 		if err != nil {
 			return fmt.Errorf("Creating Client: %w", err)
 		}

--- a/util/client.go
+++ b/util/client.go
@@ -65,7 +65,11 @@ func GetClient(ctx context.Context) (*api.Client, error) {
 		fmt.Println()
 	}
 
-	client, err := api.NewClient(nil, "", serverAddress, userPrivateKey, userPassword)
+	httpClient, err := GetHttpClient()
+	if err != nil {
+		return nil, err
+	}
+	client, err := api.NewClient(httpClient, "", serverAddress, userPrivateKey, userPassword)
 	if err != nil {
 		return nil, fmt.Errorf("Creating Client: %w", err)
 	}

--- a/util/http.go
+++ b/util/http.go
@@ -17,12 +17,12 @@ func GetClientCertificate() (tls.Certificate, error) {
 		return tls.Certificate{}, nil
 	}
 	if certExists && !keyExists {
-		return tls.Certificate{}, fmt.Errorf("Client TLS private key is empty, but client TLS cert was sent.")
+		return tls.Certificate{}, fmt.Errorf("Client TLS private key is empty, but client TLS cert was set.")
 	}
 	if !certExists && keyExists {
-		return tls.Certificate{}, fmt.Errorf("Client TLS cert is empty, but client TLS private key was sent.")
+		return tls.Certificate{}, fmt.Errorf("Client TLS cert is empty, but client TLS private key was set.")
 	}
-	return tls.LoadX509KeyPair("client.cert", "client-key.pem")
+	return tls.LoadX509KeyPair(cert, key)
 }
 
 func GetHttpClient() (*http.Client, error) {

--- a/util/http.go
+++ b/util/http.go
@@ -22,7 +22,7 @@ func GetClientCertificate() (tls.Certificate, error) {
 	if !certExists && keyExists {
 		return tls.Certificate{}, fmt.Errorf("Client TLS cert is empty, but client TLS private key was set.")
 	}
-	return tls.LoadX509KeyPair(cert, key)
+	return tls.X509KeyPair([]byte(cert), []byte(key))
 }
 
 func GetHttpClient() (*http.Client, error) {

--- a/util/http.go
+++ b/util/http.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/viper"
+)
+
+func GetClientCertificate() (tls.Certificate, error) {
+	cert := viper.GetString("tlsClientCert")
+	certExists := cert != ""
+	key := viper.GetString("tlsClientPrivateKey")
+	keyExists := key != ""
+	if !certExists && !keyExists {
+		return tls.Certificate{}, nil
+	}
+	if certExists && !keyExists {
+		return tls.Certificate{}, fmt.Errorf("Client TLS private key is empty, but client TLS cert was sent.")
+	}
+	if !certExists && keyExists {
+		return tls.Certificate{}, fmt.Errorf("Client TLS cert is empty, but client TLS private key was sent.")
+	}
+	return tls.LoadX509KeyPair("client.cert", "client-key.pem")
+}
+
+func GetHttpClient() (*http.Client, error) {
+	tlsSkipVerify := viper.GetBool("tlsSkipVerify")
+	cert, err := GetClientCertificate()
+	if err != nil {
+		return nil, err
+	}
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates:       []tls.Certificate{cert},
+				InsecureSkipVerify: tlsSkipVerify,
+			},
+		},
+	}
+
+	return &httpClient, nil
+}


### PR DESCRIPTION
This PR adds support for some http client configurations. It adds support to:

-  disable the tls server certificate verification with '--tlsSkipVerify' argument

- attach a client certificate on http request
