### PR TITLE
[ease-of-use] Display "Enter Password" on STDERR

### DIFF
--- a/util/client.go
+++ b/util/client.go
@@ -22,7 +22,7 @@ func ReadPassword(prompt string) (string, error) {
 	fd := int(os.Stdin.Fd())
 	var pass string
 	if term.IsTerminal(fd) {
-		fmt.Print(prompt)
+		fmt.Fprint(os.Stderr, prompt);
 
 		inputPass, err := term.ReadPassword(fd)
 		if err != nil {


### PR DESCRIPTION
This enables users to sequence `passbolt` commands ahead of common processors... such as:

```
passbolt list resource | fzf
passbolt get resource -j abc-123-321-cba | jq ".Password"
```

As is, displaying the prompt on STDIN means the prompt (and occasionally user response) is gobbled up by the second command in the sequence. STDERR is a common out-of-band backup for interactive prompts in many similar cases.

I am inexperienced in Golang, and am unsure how solid this is; simply queried the ideal API call.