### PR TITLE
Adding folder structure to export for Keepass

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ passbolt exec -- gh auth login
 
 This would resolve the passbolt:// reference in GITHUB_TOKEN to its actual secret value and pass it to the gh process.
 
+# Exporting Data
+## Keepass Export
+You can export your Passbolt passwords to a Keepass (.kdbx) file while preserving the folder structure.
+
+Save your passbolt configuration first.
+```bash
+passbolt configure --config passbolt_server_details.json --serverAddress https://example.com --userPassword 'secret_passbolt_passphrase' --userPrivateKeyFile '/path/to/private/key/ada_private.key' --tlsSkipVerify
+```
+
+Then export your data to a password encrypted keepass file.
+```bash
+passbolt export keepass --file exported-passwords.kdbx -p password_for_keepass_file
+```
+
+The export preserves the folder structure from Passbolt, including nested folders. Resources not in any folder will be placed in an "Unfiled Resources" group.
+
+The export supports both password and TOTP resources. TOTP secrets are exported in a format compatible with standard authenticator apps.
+
+Note: This feature supports Passbolt v4 up to v5.2.0 but does not support Passbolt instances with encrypted metadata enabled.
+
 # Documentation
 Usage for all Subcommands is [here](https://github.com/passbolt/go-passbolt-cli/wiki/passbolt).
 And is also available via `man passbolt`


### PR DESCRIPTION
## PR: Add Folder Structure Support to Keepass Export

### Description
This PR adds folder structure support to Keepass exports, maintaining the folder hierarchy from Passbolt when exporting to a Keepass (.kdbx) file. Previously, resources were exported to a flat structure.

### Changes
- Added logic to retrieve folder information with nested resources and child folders
- Implemented recursive folder structure building
- Created an "Unfiled Resources" group for resources not in folders
- Added logging during export
- Updated resource handling to associate resources with folders
- Updated README with export instructions and examples

### Features Supported
- Password resources with standard fields
- TOTP resources (both standalone and combined with passwords)
- Nested folder structures

### Testing
Tested with:
- Nested folders with multiple levels
- Empty folders
- Resources in multiple folders
- Resources without folders
- TOTP and password resources

### Compatibility
- Supports Passbolt v4 up to v5.2.0
- No support for Passbolt with encrypted metadata enabled