### PR TITLE
Add HTTP proxy support via standard environment variables

### DIFF
--- a/util/http.go
+++ b/util/http.go
@@ -33,6 +33,7 @@ func GetHttpClient() (*http.Client, error) {
 	}
 	httpClient := http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				Certificates:       []tls.Certificate{cert},
 				InsecureSkipVerify: tlsSkipVerify,


### PR DESCRIPTION
Configure HTTP transport to respect HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables by using http.ProxyFromEnvironment.