### PR TITLE
perf: optimize listing performance

### DIFF
--- a/resource/decrypt.go
+++ b/resource/decrypt.go
@@ -1,0 +1,71 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/passbolt/go-passbolt/api"
+	"github.com/passbolt/go-passbolt/helper"
+)
+
+// decryptedResource holds the decrypted fields from a resource
+type decryptedResource struct {
+	name        string
+	username    string
+	uri         string
+	password    string
+	description string
+}
+
+// decryptResource decrypts a resource's secret and returns the decrypted fields.
+// It uses the provided resourceTypeCache to avoid fetching the same ResourceType multiple times.
+// If the resource has pre-populated fields (Passbolt v3/v4), it uses those when secrets aren't needed.
+func decryptResource(
+	ctx context.Context,
+	client *api.Client,
+	resource api.Resource,
+	needsDecryption bool,
+	resourceTypeCache map[string]*api.ResourceType,
+) (decryptedResource, error) {
+	result := decryptedResource{
+		name:        resource.Name,
+		username:    resource.Username,
+		uri:         resource.URI,
+		description: resource.Description,
+	}
+
+	// If we don't need decryption or no secrets available, return existing fields
+	if !needsDecryption || len(resource.Secrets) == 0 {
+		return result, nil
+	}
+
+	// Check cache first
+	rType, exists := resourceTypeCache[resource.ResourceTypeID]
+	if !exists {
+		var err error
+		rType, err = client.GetResourceType(ctx, resource.ResourceTypeID)
+		if err != nil {
+			return result, fmt.Errorf("Get ResourceType: %w", err)
+		}
+		resourceTypeCache[resource.ResourceTypeID] = rType
+	}
+
+	// Decrypt using the secret
+	_, name, username, uri, password, description, err := helper.GetResourceFromData(
+		client,
+		resource,
+		resource.Secrets[0],
+		*rType,
+	)
+	if err != nil {
+		return result, fmt.Errorf("Decrypt Resource: %w", err)
+	}
+
+	result.name = name
+	result.username = username
+	result.uri = uri
+	result.password = password
+	result.description = description
+
+	return result, nil
+}


### PR DESCRIPTION
First, thank you for creating and maintaining this great project! It has been fantastic for us integrating Passbolt into our workflows.

### The problem!

When working with several hundred credentials, `passbolt list resource` became unusable due to request timeouts. 

The command would consistently fail with:
`Error: Get Resource Getting Resource Secret: Doing Request: Request Context: context deadline exceeded`

### Root Cause

The resource listing implementation suffered from a N+1 query problem:

  1. **Initial request**: Fetch list of all resources (1 API call)
  2. **Per-resource requests**: Call `helper.GetResource()` individually for each resource to decrypt fields (N API calls)

With 300+ credentials, this resulted in 300+ sequential API calls, exceeding the default context timeout.

The code had a TODO comment acknowledging this performance issue but it had not been addressed yet.

### Solution

This PR eliminates the N+1 problem using Passbolt API's existing `contain[secret]` parameter to fetch all data in bulk, then decrypt locally:

  **1. Bulk Secret Fetching**
  - Added `ContainSecret: true` to `GetResourcesOptions` when encrypted fields are needed
  - Reduces 300+ sequential API calls to 1 bulk request

  **2. Decryption-need detection**
  - Only fetches secrets when encrypted columns (Name, Username, URI, Password, Description) are requested via `--column` flag or CEL filters
  - Keeps metadata-only queries lightweight

  **3. Local Decryption** (resource/decrypt.go)
  - New centralized `decryptResource()` helper using `helper.GetResourceFromData()`
  - Decrypts secrets client-side without additional API calls
  - Eliminates code duplication across list and filter operations

  **4. ResourceType Caching**
  - Caches ResourceType objects to avoid duplicate fetches (typically 3-6 unique types per instance)

  **5. Additional Improvements**
  - JSON output now respects `--column` flag (previously ignored)
  - Fixed CEL variable name: `"Id"` → `"ID"` for correct ID-based filtering

### Backward Compatibility

Tested manually to be compatible with Passbolt v3, v4, and v5

### Testing

```bash
# Build
go build -o passbolt

# Test with large credential set
./passbolt list resource

# Test column filtering (only fetches what's needed)
./passbolt list resource -c ID,FolderParentID,CreatedTimestamp  # No decryption
./passbolt list resource -c ID,Name,Username                     # With decryption

# Test CEL filters
./passbolt list resource --filter 'Name.startsWith("prod")'

# Test JSON output with column selection
./passbolt list resource --json -c ID,Name,Username
```

This should make the CLI practical for teams / organizations with loads of credentials. It's especially important for Passbolt v5 where Name, Username, URI, and Description fields are now encrypted in the metadata rather than being available as plaintext.

Looking forward to your feedback!