### PR TITLE
fix assign error from delete resource

### DIFF
--- a/resource/delete.go
+++ b/resource/delete.go
@@ -35,7 +35,7 @@ func ResourceDelete(cmd *cobra.Command, args []string) error {
 	defer client.Logout(context.TODO())
 	cmd.SilenceUsage = true
 
-	client.DeleteResource(ctx, resourceID)
+	err = client.DeleteResource(ctx, resourceID)
 	if err != nil {
 		return fmt.Errorf("Deleting Resource: %w", err)
 	}


### PR DESCRIPTION
Actual the error is ignored; the if err != nil check never fires, making it appear as if the deletion succeeded.