### PR TITLE
fix: skip failing resources instead of aborting listing

### DIFF
--- a/resource/filter.go
+++ b/resource/filter.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/google/cel-go/cel"
 	"github.com/passbolt/go-passbolt-cli/util"
@@ -39,7 +40,8 @@ func filterResources(resources *[]api.Resource, celCmd string, ctx context.Conte
 		// TODO We should decrypt the secret only when required for performance reasonse
 		_, name, username, uri, pass, desc, err := helper.GetResource(ctx, client, resource.ID)
 		if err != nil {
-			return nil, fmt.Errorf("Get Resource %w", err)
+			fmt.Fprintf(os.Stderr, "Warning: Skipping resource %v: %v\n", resource.ID, err)
+			continue
 		}
 
 		val, _, err := (*program).ContextEval(ctx, map[string]any{

--- a/resource/list.go
+++ b/resource/list.go
@@ -95,7 +95,8 @@ func ResourceList(cmd *cobra.Command, args []string) error {
 		for i := range resources {
 			_, name, username, uri, pass, desc, err := helper.GetResource(ctx, client, resources[i].ID)
 			if err != nil {
-				return fmt.Errorf("Get Resource %w", err)
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Skipping resource %v: %v\n", resources[i].ID, err)
+				continue
 			}
 			outputResources = append(outputResources, ResourceJsonOutput{
 				ID:                &resources[i].ID,
@@ -121,7 +122,8 @@ func ResourceList(cmd *cobra.Command, args []string) error {
 			// TODO We should decrypt the secret only when required for performance reasonse
 			_, name, username, uri, pass, desc, err := helper.GetResource(ctx, client, resource.ID)
 			if err != nil {
-				return fmt.Errorf("Get Resource %w", err)
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Skipping resource %v: %v\n", resource.ID, err)
+				continue
 			}
 
 			entry := make([]string, len(columns))


### PR DESCRIPTION
## Summary

When a single resource fails to decrypt (e.g. malformed secret data, unsupported resource type, or request timeout), the `list resource` command aborts entirely with an error. This makes the command unusable on instances with even one problematic resource.

This patch makes the listing resilient by:
- Printing a warning to stderr for each skipped resource
- Continuing with the next resource instead of returning an error

Affected code paths:
- `resource/list.go`: JSON output loop and table output loop
- `resource/filter.go`: CEL filter evaluation loop

## Context

On a Passbolt v5 instance with ~1270 resources, the `list resource` command was failing due to individual resources with parsing issues. With this fix, all valid resources are listed and problematic ones are reported as warnings.

## Test plan

- [ ] Verify `list resource` completes even when some resources fail to decrypt
- [ ] Verify warnings are printed to stderr for skipped resources
- [ ] Verify JSON and table output modes both handle failures gracefully
- [ ] Verify CEL filter mode skips failing resources