### PR TITLE
PB-50130 - Go-Cli: Add a manual workflow step to be able to manually execute the releases

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -3,6 +3,12 @@ name: Update Homebrew Tap
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.4.2)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -10,12 +16,13 @@ permissions:
 jobs:
   homebrew:
     runs-on: ubuntu-latest
-    if: "!github.event.release.prerelease"
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -41,5 +48,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/go-passbolt-cli.rb
-          git commit -m "Update go-passbolt-cli to ${{ github.event.release.tag_name }}"
+          git commit -m "Update go-passbolt-cli to ${{ github.event.release.tag_name || inputs.tag }}"
           git push


### PR DESCRIPTION
If the CI pipeline fails and the release fails, there is no way to manually re-run it.
We add a workflow that we can trigger manually.

Signed-off-by: Cédric HERZOG <cedric.herzog@passbolt.com>