### PR TITLE
PB-50163 - Go-Cli : schema-driven resource type support

### DIFF
--- a/keepass/export.go
+++ b/keepass/export.go
@@ -30,6 +30,7 @@ var KeepassExportCmd = &cobra.Command{
 func init() {
 	KeepassExportCmd.Flags().StringP("file", "f", "passbolt-export.kdbx", "File name of the KeePass File")
 	KeepassExportCmd.Flags().StringP("password", "p", "", "Password for the KeePass File, if empty prompts interactively")
+	KeepassExportCmd.Flags().Bool("aes-kdf", false, "Use AES-KDF (KDBX 3.1) instead of Argon2 (KDBX 4); needed by importers that don't support Argon2")
 }
 
 func KeepassExport(cmd *cobra.Command, args []string) error {
@@ -43,6 +44,11 @@ func KeepassExport(cmd *cobra.Command, args []string) error {
 	}
 
 	keepassPassword, err := cmd.Flags().GetString("password")
+	if err != nil {
+		return err
+	}
+
+	useAESKDF, err := cmd.Flags().GetBool("aes-kdf")
 	if err != nil {
 		return err
 	}
@@ -105,9 +111,11 @@ func KeepassExport(cmd *cobra.Command, args []string) error {
 		progressbar.Increment()
 	}
 
-	db := gokeepasslib.NewDatabase(
-		gokeepasslib.WithDatabaseKDBXVersion4(),
-	)
+	kdbxVersion := gokeepasslib.WithDatabaseKDBXVersion4()
+	if useAESKDF {
+		kdbxVersion = gokeepasslib.WithDatabaseKDBXVersion3()
+	}
+	db := gokeepasslib.NewDatabase(kdbxVersion)
 	db.Content.Meta.DatabaseName = "Passbolt Export"
 
 	if keepassPassword != "" {

--- a/keepass/export.go
+++ b/keepass/export.go
@@ -29,7 +29,7 @@ var KeepassExportCmd = &cobra.Command{
 func init() {
 	KeepassExportCmd.Flags().StringP("file", "f", "passbolt-export.kdbx", "File name of the KeePass File")
 	KeepassExportCmd.Flags().StringP("password", "p", "", "Password for the KeePass File, if empty prompts interactively")
-	KeepassExportCmd.Flags().Bool("aes-kdf", false, "Use AES-KDF (KDBX 3.1) instead of Argon2 (KDBX 4); needed by importers that don't support Argon2")
+	KeepassExportCmd.Flags().String("kdbx-version", "v3", "KDBX format version: v3 (AES-KDF, KDBX 3.1) or v4 (Argon2, KDBX 4)")
 }
 
 func KeepassExport(cmd *cobra.Command, args []string) error {
@@ -47,9 +47,19 @@ func KeepassExport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	useAESKDF, err := cmd.Flags().GetBool("aes-kdf")
+	kdbxVersionFlag, err := cmd.Flags().GetString("kdbx-version")
 	if err != nil {
 		return err
+	}
+
+	var kdbxVersion gokeepasslib.DatabaseOption
+	switch kdbxVersionFlag {
+	case "v3":
+		kdbxVersion = gokeepasslib.WithDatabaseKDBXVersion3()
+	case "v4":
+		kdbxVersion = gokeepasslib.WithDatabaseKDBXVersion4()
+	default:
+		return fmt.Errorf("invalid kdbx-version %q: must be v3 or v4", kdbxVersionFlag)
 	}
 
 	ctx, cancel := util.GetContext()
@@ -110,10 +120,6 @@ func KeepassExport(cmd *cobra.Command, args []string) error {
 		progressbar.Increment()
 	}
 
-	kdbxVersion := gokeepasslib.WithDatabaseKDBXVersion4()
-	if useAESKDF {
-		kdbxVersion = gokeepasslib.WithDatabaseKDBXVersion3()
-	}
 	db := gokeepasslib.NewDatabase(kdbxVersion)
 	db.Content.Meta.DatabaseName = "Passbolt Export"
 

--- a/keepass/export.go
+++ b/keepass/export.go
@@ -175,6 +175,11 @@ func getKeepassEntry(client *api.Client, resource api.Resource, secret api.Secre
 				totpData.Period = int(p)
 			}
 
+			// Skip TOTP entry if secret_key is missing — can't build a valid OTP URI
+			if totpData.SecretKey == "" {
+				return &entry, nil
+			}
+
 			v := url.Values{}
 			v.Set("secret", totpData.SecretKey)
 			v.Set("period", strconv.FormatUint(uint64(totpData.Period), 10))

--- a/keepass/export.go
+++ b/keepass/export.go
@@ -1,7 +1,6 @@
 package keepass
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -140,10 +139,16 @@ func KeepassExport(cmd *cobra.Command, args []string) error {
 }
 
 func getKeepassEntry(client *api.Client, resource api.Resource, secret api.Secret, rType api.ResourceType) (*gokeepasslib.Entry, error) {
-	_, name, username, uri, pass, desc, err := helper.GetResourceFromData(client, resource, resource.Secrets[0], resource.ResourceType)
+	_, metadata, secretFields, err := helper.GetResourceFieldMaps(client, resource, secret, rType, true)
 	if err != nil {
 		return nil, fmt.Errorf("get Resource %v: %w", resource.ID, err)
 	}
+
+	name := helper.GetStringField(metadata, "name")
+	username := helper.GetStringField(metadata, "username")
+	uri := helper.GetStringField(metadata, "uri")
+	password := helper.GetStringField(secretFields, "password")
+	description := helper.GetStringField(metadata, "description")
 
 	entry := gokeepasslib.NewEntry()
 	entry.Values = append(
@@ -151,48 +156,28 @@ func getKeepassEntry(client *api.Client, resource api.Resource, secret api.Secre
 		gokeepasslib.ValueData{Key: "Title", Value: gokeepasslib.V{Content: name}},
 		gokeepasslib.ValueData{Key: "UserName", Value: gokeepasslib.V{Content: username}},
 		gokeepasslib.ValueData{Key: "URL", Value: gokeepasslib.V{Content: uri}},
-		gokeepasslib.ValueData{Key: "Password", Value: gokeepasslib.V{Content: pass, Protected: w.NewBoolWrapper(true)}},
-		gokeepasslib.ValueData{Key: "Notes", Value: gokeepasslib.V{Content: desc}},
+		gokeepasslib.ValueData{Key: "Password", Value: gokeepasslib.V{Content: password, Protected: w.NewBoolWrapper(true)}},
+		gokeepasslib.ValueData{Key: "Notes", Value: gokeepasslib.V{Content: description}},
 	)
 
-	// Extract TOTP data using generic map-based approach
-	if rType.HasSecretField("totp") {
-		rawSecretData, err := client.DecryptMessage(resource.Secrets[0].Data)
-		if err != nil {
-			return nil, fmt.Errorf("decrypting Secret Data: %w", err)
-		}
-
-		var secretMap map[string]any
-		err = json.Unmarshal([]byte(rawSecretData), &secretMap)
-		if err != nil {
-			return nil, fmt.Errorf("parsing Decrypted Secret Data: %w", err)
-		}
-
-		if totpRaw, ok := secretMap["totp"].(map[string]any); ok {
-			totpData := api.SecretDataTOTP{}
-			if s, ok := totpRaw["secret_key"].(string); ok {
-				totpData.SecretKey = s
-			}
-			if s, ok := totpRaw["algorithm"].(string); ok {
-				totpData.Algorithm = s
-			}
+	if totpRaw, ok := secretFields["totp"].(map[string]any); ok {
+		secretKey, _ := totpRaw["secret_key"].(string)
+		// Skip TOTP entry if secret_key is missing — can't build a valid OTP URI
+		if secretKey != "" {
+			algorithm, _ := totpRaw["algorithm"].(string)
+			var digits, period int
 			if d, ok := totpRaw["digits"].(float64); ok {
-				totpData.Digits = int(d)
+				digits = int(d)
 			}
 			if p, ok := totpRaw["period"].(float64); ok {
-				totpData.Period = int(p)
-			}
-
-			// Skip TOTP entry if secret_key is missing — can't build a valid OTP URI
-			if totpData.SecretKey == "" {
-				return &entry, nil
+				period = int(p)
 			}
 
 			v := url.Values{}
-			v.Set("secret", totpData.SecretKey)
-			v.Set("period", strconv.FormatUint(uint64(totpData.Period), 10))
-			v.Set("algorithm", totpData.Algorithm)
-			v.Set("digits", fmt.Sprint(totpData.Digits))
+			v.Set("secret", secretKey)
+			v.Set("period", strconv.FormatUint(uint64(period), 10))
+			v.Set("algorithm", algorithm)
+			v.Set("digits", fmt.Sprint(digits))
 
 			issuer := uri
 			if uri == "" {
@@ -216,7 +201,48 @@ func getKeepassEntry(client *api.Client, resource api.Resource, secret api.Secre
 		}
 	}
 
+	// Custom fields: each one becomes a protected KDBX field, matching what the
+	// Passbolt browser extension does in resourcesKdbxExporter.setCustomFields.
+	// Field name comes from metadata.custom_fields[].metadata_key, value from
+	// secret.custom_fields[].secret_value, correlated by id.
+	addCustomFields(&entry, metadata, secretFields)
+
 	return &entry, nil
+}
+
+func addCustomFields(entry *gokeepasslib.Entry, metadata, secretFields map[string]any) {
+	metaList, _ := metadata["custom_fields"].([]any)
+	if len(metaList) == 0 {
+		return
+	}
+	secretList, _ := secretFields["custom_fields"].([]any)
+	valueByID := make(map[string]string, len(secretList))
+	for _, item := range secretList {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := m["id"].(string)
+		val, _ := m["secret_value"].(string)
+		if id != "" {
+			valueByID[id] = val
+		}
+	}
+	for _, item := range metaList {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := m["id"].(string)
+		key, _ := m["metadata_key"].(string)
+		if key == "" {
+			continue
+		}
+		entry.Values = append(entry.Values, gokeepasslib.ValueData{
+			Key:   key,
+			Value: gokeepasslib.V{Content: valueByID[id], Protected: w.NewBoolWrapper(true)},
+		})
+	}
 }
 
 // EncodeQuery is a copy-paste of url.Values.Encode, except it uses %20 instead

--- a/keepass/export.go
+++ b/keepass/export.go
@@ -147,71 +147,60 @@ func getKeepassEntry(client *api.Client, resource api.Resource, secret api.Secre
 		gokeepasslib.ValueData{Key: "Notes", Value: gokeepasslib.V{Content: desc}},
 	)
 
-	if resource.ResourceType.Slug == "password-description-totp" || resource.ResourceType.Slug == "totp" || resource.ResourceType.Slug == "v5-default-with-totp" || resource.ResourceType.Slug == "v5-totp-standalone" {
-		var totpData api.SecretDataTOTP
-
+	// Extract TOTP data using generic map-based approach
+	if rType.HasSecretField("totp") {
 		rawSecretData, err := client.DecryptMessage(resource.Secrets[0].Data)
 		if err != nil {
 			return nil, fmt.Errorf("decrypting Secret Data: %w", err)
 		}
 
-		switch resource.ResourceType.Slug {
-		case "password-description-totp":
-			var secretData api.SecretDataTypePasswordDescriptionTOTP
-			err = json.Unmarshal([]byte(rawSecretData), &secretData)
-			if err != nil {
-				return nil, fmt.Errorf("parsing Decrypted Secret Data: %w", err)
-			}
-			totpData = secretData.TOTP
-		case "totp":
-			var secretData api.SecretDataTypeTOTP
-			err = json.Unmarshal([]byte(rawSecretData), &secretData)
-			if err != nil {
-				return nil, fmt.Errorf("parsing Decrypted Secret Data: %w", err)
-			}
-			totpData = secretData.TOTP
-		case "v5-default-with-totp":
-			var secretData api.SecretDataTypeV5DefaultWithTOTP
-			err = json.Unmarshal([]byte(rawSecretData), &secretData)
-			if err != nil {
-				return nil, fmt.Errorf("parsing Decrypted Secret Data: %w", err)
-			}
-			totpData = secretData.TOTP
-		case "v5-totp-standalone":
-			var secretData api.SecretDataTypeV5TOTPStandalone
-			err = json.Unmarshal([]byte(rawSecretData), &secretData)
-			if err != nil {
-				return nil, fmt.Errorf("parsing Decrypted Secret Data: %w", err)
-			}
-			totpData = secretData.TOTP
+		var secretMap map[string]any
+		err = json.Unmarshal([]byte(rawSecretData), &secretMap)
+		if err != nil {
+			return nil, fmt.Errorf("parsing Decrypted Secret Data: %w", err)
 		}
 
-		v := url.Values{}
-		v.Set("secret", totpData.SecretKey)
-		v.Set("period", strconv.FormatUint(uint64(totpData.Period), 10))
-		v.Set("algorithm", totpData.Algorithm)
-		v.Set("digits", fmt.Sprint(totpData.Digits))
+		if totpRaw, ok := secretMap["totp"].(map[string]any); ok {
+			totpData := api.SecretDataTOTP{}
+			if s, ok := totpRaw["secret_key"].(string); ok {
+				totpData.SecretKey = s
+			}
+			if s, ok := totpRaw["algorithm"].(string); ok {
+				totpData.Algorithm = s
+			}
+			if d, ok := totpRaw["digits"].(float64); ok {
+				totpData.Digits = int(d)
+			}
+			if p, ok := totpRaw["period"].(float64); ok {
+				totpData.Period = int(p)
+			}
 
-		issuer := uri
-		if uri == "" {
-			issuer = name
+			v := url.Values{}
+			v.Set("secret", totpData.SecretKey)
+			v.Set("period", strconv.FormatUint(uint64(totpData.Period), 10))
+			v.Set("algorithm", totpData.Algorithm)
+			v.Set("digits", fmt.Sprint(totpData.Digits))
 
+			issuer := uri
+			if uri == "" {
+				issuer = name
+			}
+			v.Set("issuer", issuer)
+
+			accountName := username
+			if username == "" {
+				accountName = name
+			}
+
+			u := url.URL{
+				Scheme:   "otpauth",
+				Host:     "totp",
+				Path:     "/" + issuer + ":" + accountName,
+				RawQuery: encodeQuery(v),
+			}
+
+			entry.Values = append(entry.Values, gokeepasslib.ValueData{Key: "otp", Value: gokeepasslib.V{Content: u.String(), Protected: w.NewBoolWrapper(true)}})
 		}
-		v.Set("issuer", issuer)
-
-		accountName := username
-		if username == "" {
-			accountName = name
-		}
-
-		u := url.URL{
-			Scheme:   "otpauth",
-			Host:     "totp",
-			Path:     "/" + issuer + ":" + accountName,
-			RawQuery: encodeQuery(v),
-		}
-
-		entry.Values = append(entry.Values, gokeepasslib.ValueData{Key: "otp", Value: gokeepasslib.V{Content: u.String(), Protected: w.NewBoolWrapper(true)}})
 	}
 
 	return &entry, nil

--- a/resource/create.go
+++ b/resource/create.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/passbolt/go-passbolt-cli/util"
+	"github.com/passbolt/go-passbolt/api"
 	"github.com/passbolt/go-passbolt/helper"
 	"github.com/spf13/cobra"
 )
@@ -132,7 +133,11 @@ func ResourceCreate(cmd *cobra.Command, args []string) error {
 		}
 
 		if resourceType == "" {
-			resourceType = "v5-default" // default to v5 when using generic flags
+			if client.MetadataTypeSettings().DefaultResourceType == api.PassboltAPIVersionTypeV5 {
+				resourceType = "v5-default"
+			} else {
+				resourceType = "password-and-description"
+			}
 		}
 
 		id, err = helper.CreateResourceGeneric(ctx, client, resourceType, folderParentID, metadataFields, secretFieldsMap)

--- a/resource/create.go
+++ b/resource/create.go
@@ -27,22 +27,55 @@ func init() {
 	ResourceCreateCmd.Flags().StringP("folderParentID", "f", "", "Folder in which to create the Resource")
 	ResourceCreateCmd.Flags().String("expiry", "", "Expiry as RFC3339 (e.g. 2025-12-31T23:59:59Z) or Go duration (e.g. 48h, 30m)")
 	ResourceCreateCmd.Flags().String("type", "", "Resource type slug (e.g. v5-default, password-and-description, v5-custom-fields)")
-	ResourceCreateCmd.Flags().StringArray("field", []string{}, "Metadata field as key=value (repeatable)")
-	ResourceCreateCmd.Flags().StringArray("secret-field", []string{}, "Secret field as key=value (repeatable)")
+	ResourceCreateCmd.Flags().StringArray("field", []string{}, "Metadata field as key=value (repeatable; JSON values like [\"a\"] are parsed automatically)")
+	ResourceCreateCmd.Flags().StringArray("secret-field", []string{}, "Secret field as key=value (repeatable; JSON values are parsed automatically)")
 }
 
 func ResourceCreate(cmd *cobra.Command, args []string) error {
-	name, _ := cmd.Flags().GetString("name")
-	username, _ := cmd.Flags().GetString("username")
-	uri, _ := cmd.Flags().GetString("uri")
-	password, _ := cmd.Flags().GetString("password")
-	description, _ := cmd.Flags().GetString("description")
-	folderParentID, _ := cmd.Flags().GetString("folderParentID")
-	expiry, _ := cmd.Flags().GetString("expiry")
-	resourceType, _ := cmd.Flags().GetString("type")
-	fields, _ := cmd.Flags().GetStringArray("field")
-	secretFields, _ := cmd.Flags().GetStringArray("secret-field")
-	jsonOutput, _ := cmd.Flags().GetBool("json")
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+	username, err := cmd.Flags().GetString("username")
+	if err != nil {
+		return err
+	}
+	uri, err := cmd.Flags().GetString("uri")
+	if err != nil {
+		return err
+	}
+	password, err := cmd.Flags().GetString("password")
+	if err != nil {
+		return err
+	}
+	description, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return err
+	}
+	folderParentID, err := cmd.Flags().GetString("folderParentID")
+	if err != nil {
+		return err
+	}
+	expiry, err := cmd.Flags().GetString("expiry")
+	if err != nil {
+		return err
+	}
+	resourceType, err := cmd.Flags().GetString("type")
+	if err != nil {
+		return err
+	}
+	fields, err := cmd.Flags().GetStringArray("field")
+	if err != nil {
+		return err
+	}
+	secretFields, err := cmd.Flags().GetStringArray("secret-field")
+	if err != nil {
+		return err
+	}
+	jsonOutput, err := cmd.Flags().GetBool("json")
+	if err != nil {
+		return err
+	}
 
 	useGeneric := resourceType != "" || len(fields) > 0 || len(secretFields) > 0
 
@@ -71,12 +104,7 @@ func ResourceCreate(cmd *cobra.Command, args []string) error {
 			metadataFields["username"] = username
 		}
 		if uri != "" {
-			// Will be set as "uris" or "uri" by CreateResourceGeneric based on type
-			if resourceType != "" && strings.HasPrefix(resourceType, "v5-") {
-				metadataFields["uris"] = []string{uri}
-			} else {
-				metadataFields["uri"] = uri
-			}
+			metadataFields["uri"] = uri
 		}
 		if description != "" {
 			metadataFields["description"] = description

--- a/resource/create.go
+++ b/resource/create.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/passbolt/go-passbolt-cli/util"
 	"github.com/passbolt/go-passbolt/helper"
@@ -25,45 +26,25 @@ func init() {
 	ResourceCreateCmd.Flags().StringP("description", "d", "", "Resource Description")
 	ResourceCreateCmd.Flags().StringP("folderParentID", "f", "", "Folder in which to create the Resource")
 	ResourceCreateCmd.Flags().String("expiry", "", "Expiry as RFC3339 (e.g. 2025-12-31T23:59:59Z) or Go duration (e.g. 48h, 30m)")
-	ResourceCreateCmd.MarkFlagRequired("name")
-	ResourceCreateCmd.MarkFlagRequired("password")
+	ResourceCreateCmd.Flags().String("type", "", "Resource type slug (e.g. v5-default, password-and-description, v5-custom-fields)")
+	ResourceCreateCmd.Flags().StringArray("field", []string{}, "Metadata field as key=value (repeatable)")
+	ResourceCreateCmd.Flags().StringArray("secret-field", []string{}, "Secret field as key=value (repeatable)")
 }
 
 func ResourceCreate(cmd *cobra.Command, args []string) error {
-	folderParentID, err := cmd.Flags().GetString("folderParentID")
-	if err != nil {
-		return err
-	}
-	name, err := cmd.Flags().GetString("name")
-	if err != nil {
-		return err
-	}
-	username, err := cmd.Flags().GetString("username")
-	if err != nil {
-		return err
-	}
-	uri, err := cmd.Flags().GetString("uri")
-	if err != nil {
-		return err
-	}
-	password, err := cmd.Flags().GetString("password")
-	if err != nil {
-		return err
-	}
-	description, err := cmd.Flags().GetString("description")
-	if err != nil {
-		return err
-	}
+	name, _ := cmd.Flags().GetString("name")
+	username, _ := cmd.Flags().GetString("username")
+	uri, _ := cmd.Flags().GetString("uri")
+	password, _ := cmd.Flags().GetString("password")
+	description, _ := cmd.Flags().GetString("description")
+	folderParentID, _ := cmd.Flags().GetString("folderParentID")
+	expiry, _ := cmd.Flags().GetString("expiry")
+	resourceType, _ := cmd.Flags().GetString("type")
+	fields, _ := cmd.Flags().GetStringArray("field")
+	secretFields, _ := cmd.Flags().GetStringArray("secret-field")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
 
-	expiry, err := cmd.Flags().GetString("expiry")
-	if err != nil {
-		return err
-	}
-
-	jsonOutput, err := cmd.Flags().GetBool("json")
-	if err != nil {
-		return err
-	}
+	useGeneric := resourceType != "" || len(fields) > 0 || len(secretFields) > 0
 
 	ctx, cancel := util.GetContext()
 	defer cancel()
@@ -75,21 +56,73 @@ func ResourceCreate(cmd *cobra.Command, args []string) error {
 	defer util.SaveSessionKeysAndLogout(ctx, client)
 	cmd.SilenceUsage = true
 
-	id, err := helper.CreateResource(
-		ctx,
-		client,
-		folderParentID,
-		name,
-		username,
-		uri,
-		password,
-		description,
-	)
-	if err != nil {
-		return fmt.Errorf("creating Resource: %w", err)
+	var id string
+
+	if useGeneric {
+		// Generic path: use CreateResourceGeneric with field maps
+		metadataFields := map[string]any{}
+		secretFieldsMap := map[string]any{}
+
+		// Map standard flags to field maps
+		if name != "" {
+			metadataFields["name"] = name
+		}
+		if username != "" {
+			metadataFields["username"] = username
+		}
+		if uri != "" {
+			// Will be set as "uris" or "uri" by CreateResourceGeneric based on type
+			if resourceType != "" && strings.HasPrefix(resourceType, "v5-") {
+				metadataFields["uris"] = []string{uri}
+			} else {
+				metadataFields["uri"] = uri
+			}
+		}
+		if description != "" {
+			metadataFields["description"] = description
+		}
+		if password != "" {
+			secretFieldsMap["password"] = password
+		}
+
+		// Parse --field flags
+		for _, f := range fields {
+			k, v, err := parseKeyValue(f)
+			if err != nil {
+				return fmt.Errorf("invalid --field: %w", err)
+			}
+			metadataFields[k] = v
+		}
+
+		// Parse --secret-field flags
+		for _, f := range secretFields {
+			k, v, err := parseKeyValue(f)
+			if err != nil {
+				return fmt.Errorf("invalid --secret-field: %w", err)
+			}
+			secretFieldsMap[k] = v
+		}
+
+		if resourceType == "" {
+			resourceType = "v5-default" // default to v5 when using generic flags
+		}
+
+		id, err = helper.CreateResourceGeneric(ctx, client, resourceType, folderParentID, metadataFields, secretFieldsMap)
+	} else {
+		// Legacy path: use standard CreateResource
+		if name == "" {
+			return fmt.Errorf("required flag \"name\" not set")
+		}
+		if password == "" {
+			return fmt.Errorf("required flag \"password\" not set")
+		}
+		id, err = helper.CreateResource(ctx, client, folderParentID, name, username, uri, password, description)
 	}
 
-	// TODO, Should be done by go-passbolt when the "new" Resource API is done
+	if err != nil {
+		return fmt.Errorf("creating resource: %w", err)
+	}
+
 	if expiry != "" {
 		if err := SetResourceExpiry(ctx, client, id, expiry); err != nil {
 			return err
@@ -97,17 +130,34 @@ func ResourceCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	if jsonOutput {
-		jsonID, err := json.MarshalIndent(
-			map[string]string{"id": id},
-			"",
-			"  ",
-		)
+		jsonID, err := json.MarshalIndent(map[string]string{"id": id}, "", "  ")
 		if err != nil {
-			return fmt.Errorf("marshaling Json: %w", err)
+			return fmt.Errorf("marshaling json: %w", err)
 		}
 		fmt.Println(string(jsonID))
 	} else {
 		fmt.Printf("ResourceID: %v\n", id)
 	}
 	return nil
+}
+
+// parseKeyValue parses a "key=value" string. If the value looks like JSON
+// (starts with [ or {), it is decoded into the appropriate Go type so that
+// it is serialized correctly when marshaled back to JSON.
+func parseKeyValue(s string) (string, any, error) {
+	parts := strings.SplitN(s, "=", 2)
+	if len(parts) != 2 {
+		return "", nil, fmt.Errorf("expected key=value, got %q", s)
+	}
+	key := parts[0]
+	val := parts[1]
+
+	trimmed := strings.TrimSpace(val)
+	if strings.HasPrefix(trimmed, "[") || strings.HasPrefix(trimmed, "{") {
+		var parsed any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil {
+			return key, parsed, nil
+		}
+	}
+	return key, val, nil
 }

--- a/resource/filter.go
+++ b/resource/filter.go
@@ -19,6 +19,8 @@ var CelEnvOptions = []cel.EnvOption{
 	cel.Variable("Description", cel.StringType),
 	cel.Variable("CreatedTimestamp", cel.TimestampType),
 	cel.Variable("ModifiedTimestamp", cel.TimestampType),
+	cel.Variable("Metadata", cel.MapType(cel.StringType, cel.DynType)),
+	cel.Variable("Secret", cel.MapType(cel.StringType, cel.DynType)),
 }
 
 // filterDecryptedResources filters already-decrypted resources by evaluating a CEL expression.
@@ -34,6 +36,16 @@ func filterDecryptedResources(resources []decryptedResource, celCmd string, ctx 
 
 	filtered := []decryptedResource{}
 	for _, d := range resources {
+		// Build metadata and secret maps for CEL, defaulting to empty maps
+		metadata := d.metadataFields
+		if metadata == nil {
+			metadata = map[string]any{}
+		}
+		secret := d.secretFields
+		if secret == nil {
+			secret = map[string]any{}
+		}
+
 		val, _, err := (*program).ContextEval(ctx, map[string]any{
 			"ID":                d.resource.ID,
 			"FolderParentID":    d.resource.FolderParentID,
@@ -44,6 +56,8 @@ func filterDecryptedResources(resources []decryptedResource, celCmd string, ctx 
 			"Description":       d.description,
 			"CreatedTimestamp":  d.resource.Created.Time,
 			"ModifiedTimestamp": d.resource.Modified.Time,
+			"Metadata":          metadata,
+			"Secret":            secret,
 		})
 
 		if err != nil {

--- a/resource/get.go
+++ b/resource/get.go
@@ -76,11 +76,17 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting secret: %w", err)
 	}
 
-	folderParentID, name, username, uri, password, description, metadata, secretFields, err :=
+	folderParentID, metadata, secretFields, err :=
 		helper.GetResourceFieldMaps(client, *resource, *secret, *rType, true)
 	if err != nil {
 		return fmt.Errorf("decrypting resource: %w", err)
 	}
+
+	name := helper.GetStringField(metadata, "name")
+	username := helper.GetStringField(metadata, "username")
+	uri := helper.GetStringField(metadata, "uri")
+	description := helper.GetStringField(metadata, "description")
+	password := helper.GetStringField(secretFields, "password")
 
 	if jsonOutput {
 		output := ResourceJSONOutput{

--- a/resource/get.go
+++ b/resource/get.go
@@ -63,24 +63,40 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 	defer util.SaveSessionKeysAndLogout(ctx, client)
 	cmd.SilenceUsage = true
 
-	folderParentID, name, username, uri, password, description, err := helper.GetResource(
-		ctx,
-		client,
-		id,
-	)
+	// Use the Resource wrapper for dynamic field access
+	r, err := helper.FetchResourceWithSecret(ctx, client, id)
 	if err != nil {
-		return fmt.Errorf("getting Resource: %w", err)
+		return fmt.Errorf("getting resource: %w", err)
 	}
 
+	folderParentID := r.FolderParentID()
+	name, _ := r.Name(ctx)
+	username, _ := r.Username(ctx)
+	uri, _ := r.URI(ctx)
+	password, _ := r.Password(ctx)
+	description, _ := r.Description(ctx)
+
 	if jsonOutput {
-		jsonResource, err := json.MarshalIndent(ResourceJSONOutput{
+		output := ResourceJSONOutput{
 			FolderParentID: &folderParentID,
 			Name:           &name,
 			Username:       &username,
 			URI:            &uri,
 			Password:       &password,
 			Description:    &description,
-		}, "", "  ")
+		}
+
+		// Include full metadata and secret maps for richer output
+		metadata, _ := r.MetadataFields(ctx)
+		secretFields, _ := r.SecretFields(ctx)
+		if len(metadata) > 0 {
+			output.Metadata = metadata
+		}
+		if len(secretFields) > 0 {
+			output.Secret = secretFields
+		}
+
+		jsonResource, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
 			return err
 		}
@@ -92,6 +108,17 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 		fmt.Printf("URI: %v\n", shellescape.StripUnsafe(uri))
 		fmt.Printf("Password: %v\n", shellescape.StripUnsafe(password))
 		fmt.Printf("Description: %v\n", shellescape.StripUnsafe(description))
+
+		// Show additional metadata fields not covered by standard output
+		metadata, _ := r.MetadataFields(ctx)
+		for k, v := range metadata {
+			switch k {
+			case "name", "username", "uri", "uris", "description", "object_type", "resource_type_id":
+				continue
+			default:
+				fmt.Printf("%s: %v\n", k, v)
+			}
+		}
 	}
 	return nil
 }

--- a/resource/get.go
+++ b/resource/get.go
@@ -70,11 +70,26 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 	}
 
 	folderParentID := r.FolderParentID()
-	name, _ := r.Name(ctx)
-	username, _ := r.Username(ctx)
-	uri, _ := r.URI(ctx)
-	password, _ := r.Password(ctx)
-	description, _ := r.Description(ctx)
+	name, err := r.Name(ctx)
+	if err != nil {
+		return fmt.Errorf("decrypting resource name: %w", err)
+	}
+	username, err := r.Username(ctx)
+	if err != nil {
+		return fmt.Errorf("decrypting resource username: %w", err)
+	}
+	uri, err := r.URI(ctx)
+	if err != nil {
+		return fmt.Errorf("decrypting resource uri: %w", err)
+	}
+	password, err := r.Password(ctx)
+	if err != nil {
+		return fmt.Errorf("decrypting resource password: %w", err)
+	}
+	description, err := r.Description(ctx)
+	if err != nil {
+		return fmt.Errorf("decrypting resource description: %w", err)
+	}
 
 	if jsonOutput {
 		output := ResourceJSONOutput{
@@ -87,8 +102,14 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 		}
 
 		// Include full metadata and secret maps for richer output
-		metadata, _ := r.MetadataFields(ctx)
-		secretFields, _ := r.SecretFields(ctx)
+		metadata, err := r.MetadataFields(ctx)
+		if err != nil {
+			return fmt.Errorf("getting metadata fields: %w", err)
+		}
+		secretFields, err := r.SecretFields(ctx)
+		if err != nil {
+			return fmt.Errorf("getting secret fields: %w", err)
+		}
 		if len(metadata) > 0 {
 			output.Metadata = metadata
 		}
@@ -110,13 +131,16 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Description: %v\n", shellescape.StripUnsafe(description))
 
 		// Show additional metadata fields not covered by standard output
-		metadata, _ := r.MetadataFields(ctx)
+		metadata, err := r.MetadataFields(ctx)
+		if err != nil {
+			return fmt.Errorf("getting metadata fields: %w", err)
+		}
 		for k, v := range metadata {
 			switch k {
 			case "name", "username", "uri", "uris", "description", "object_type", "resource_type_id":
 				continue
 			default:
-				fmt.Printf("%s: %v\n", k, v)
+				fmt.Printf("%s: %v\n", k, shellescape.StripUnsafe(fmt.Sprint(v)))
 			}
 		}
 	}

--- a/resource/get.go
+++ b/resource/get.go
@@ -63,32 +63,23 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 	defer util.SaveSessionKeysAndLogout(ctx, client)
 	cmd.SilenceUsage = true
 
-	// Use the Resource wrapper for dynamic field access
-	r, err := helper.FetchResourceWithSecret(ctx, client, id)
+	resource, err := client.GetResource(ctx, id)
 	if err != nil {
 		return fmt.Errorf("getting resource: %w", err)
 	}
+	rType, err := client.GetResourceType(ctx, resource.ResourceTypeID)
+	if err != nil {
+		return fmt.Errorf("getting resource type: %w", err)
+	}
+	secret, err := client.GetSecret(ctx, resource.ID)
+	if err != nil {
+		return fmt.Errorf("getting secret: %w", err)
+	}
 
-	folderParentID := r.FolderParentID()
-	name, err := r.Name(ctx)
+	folderParentID, name, username, uri, password, description, metadata, secretFields, err :=
+		helper.GetResourceFieldMaps(client, *resource, *secret, *rType, true)
 	if err != nil {
-		return fmt.Errorf("decrypting resource name: %w", err)
-	}
-	username, err := r.Username(ctx)
-	if err != nil {
-		return fmt.Errorf("decrypting resource username: %w", err)
-	}
-	uri, err := r.URI(ctx)
-	if err != nil {
-		return fmt.Errorf("decrypting resource uri: %w", err)
-	}
-	password, err := r.Password(ctx)
-	if err != nil {
-		return fmt.Errorf("decrypting resource password: %w", err)
-	}
-	description, err := r.Description(ctx)
-	if err != nil {
-		return fmt.Errorf("decrypting resource description: %w", err)
+		return fmt.Errorf("decrypting resource: %w", err)
 	}
 
 	if jsonOutput {
@@ -99,16 +90,6 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 			URI:            &uri,
 			Password:       &password,
 			Description:    &description,
-		}
-
-		// Include full metadata and secret maps for richer output
-		metadata, err := r.MetadataFields(ctx)
-		if err != nil {
-			return fmt.Errorf("getting metadata fields: %w", err)
-		}
-		secretFields, err := r.SecretFields(ctx)
-		if err != nil {
-			return fmt.Errorf("getting secret fields: %w", err)
 		}
 		if len(metadata) > 0 {
 			output.Metadata = metadata
@@ -130,11 +111,6 @@ func ResourceGet(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Password: %v\n", shellescape.StripUnsafe(password))
 		fmt.Printf("Description: %v\n", shellescape.StripUnsafe(description))
 
-		// Show additional metadata fields not covered by standard output
-		metadata, err := r.MetadataFields(ctx)
-		if err != nil {
-			return fmt.Errorf("getting metadata fields: %w", err)
-		}
 		for k, v := range metadata {
 			switch k {
 			case "name", "username", "uri", "uris", "description", "object_type", "resource_type_id":

--- a/resource/json.go
+++ b/resource/json.go
@@ -3,13 +3,15 @@ package resource
 import "time"
 
 type ResourceJSONOutput struct {
-	ID                *string    `json:"id,omitempty"`
-	FolderParentID    *string    `json:"folder_parent_id,omitempty"`
-	Name              *string    `json:"name,omitempty"`
-	Username          *string    `json:"username,omitempty"`
-	URI               *string    `json:"uri,omitempty"`
-	Password          *string    `json:"password,omitempty"`
-	Description       *string    `json:"description,omitempty"`
-	CreatedTimestamp  *time.Time `json:"created_timestamp,omitempty"`
-	ModifiedTimestamp *time.Time `json:"modified_timestamp,omitempty"`
+	ID                *string        `json:"id,omitempty"`
+	FolderParentID    *string        `json:"folder_parent_id,omitempty"`
+	Name              *string        `json:"name,omitempty"`
+	Username          *string        `json:"username,omitempty"`
+	URI               *string        `json:"uri,omitempty"`
+	Password          *string        `json:"password,omitempty"`
+	Description       *string        `json:"description,omitempty"`
+	CreatedTimestamp  *time.Time     `json:"created_timestamp,omitempty"`
+	ModifiedTimestamp *time.Time     `json:"modified_timestamp,omitempty"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+	Secret            map[string]any `json:"secret,omitempty"`
 }

--- a/resource/list.go
+++ b/resource/list.go
@@ -21,14 +21,16 @@ import (
 
 // decryptedResource holds the result of decrypting a single resource
 type decryptedResource struct {
-	index       int
-	resource    api.Resource
-	name        string
-	username    string
-	uri         string
-	password    string
-	description string
-	err         error
+	index          int
+	resource       api.Resource
+	name           string
+	username       string
+	uri            string
+	password       string
+	description    string
+	metadataFields map[string]any
+	secretFields   map[string]any
+	err            error
 }
 
 var defaultTableColumns = []string{"ID", "FolderParentID", "Name", "Username", "URI"}
@@ -284,7 +286,7 @@ func printJSONResources(
 		uri := d.uri
 		pass := d.password
 		desc := d.description
-		outputResources[i] = ResourceJSONOutput{
+		output := ResourceJSONOutput{
 			ID:                &d.resource.ID,
 			FolderParentID:    &d.resource.FolderParentID,
 			Name:              &name,
@@ -295,6 +297,13 @@ func printJSONResources(
 			CreatedTimestamp:  &d.resource.Created.Time,
 			ModifiedTimestamp: &d.resource.Modified.Time,
 		}
+		if len(d.metadataFields) > 0 {
+			output.Metadata = d.metadataFields
+		}
+		if len(d.secretFields) > 0 {
+			output.Secret = d.secretFields
+		}
+		outputResources[i] = output
 	}
 
 	if isColumnsChanged {

--- a/resource/list.go
+++ b/resource/list.go
@@ -80,9 +80,9 @@ func ResourceList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Check if CEL filter references Password or Description
+	// Check if CEL filter references Password, Description, or Secret
 	if !needSecrets && config.celFilter != "" {
-		refsSecrets, err := util.CELExpressionReferencesFields(config.celFilter, []string{"Password", "Description"}, CelEnvOptions...)
+		refsSecrets, err := util.CELExpressionReferencesFields(config.celFilter, []string{"Password", "Description", "Secret"}, CelEnvOptions...)
 		if err != nil {
 			return fmt.Errorf("parsing filter: %w", err)
 		}

--- a/resource/list.go
+++ b/resource/list.go
@@ -204,7 +204,7 @@ func decryptResourcesParallel(ctx context.Context, client *api.Client, resources
 					secret = resource.Secrets[0]
 				}
 
-				_, name, username, uri, pass, desc, metaFields, secFields, err := helper.GetResourceFieldMaps(
+				_, metaFields, secFields, err := helper.GetResourceFieldMaps(
 					client,
 					resource,
 					secret,
@@ -214,11 +214,11 @@ func decryptResourcesParallel(ctx context.Context, client *api.Client, resources
 				results <- decryptedResource{
 					index:          idx,
 					resource:       resource,
-					name:           name,
-					username:       username,
-					uri:            uri,
-					password:       pass,
-					description:    desc,
+					name:           helper.GetStringField(metaFields, "name"),
+					username:       helper.GetStringField(metaFields, "username"),
+					uri:            helper.GetStringField(metaFields, "uri"),
+					password:       helper.GetStringField(secFields, "password"),
+					description:    helper.GetStringField(metaFields, "description"),
 					metadataFields: metaFields,
 					secretFields:   secFields,
 					err:            err,

--- a/resource/list.go
+++ b/resource/list.go
@@ -188,6 +188,12 @@ func decryptResourcesParallel(ctx context.Context, client *api.Client, resources
 						uri:         resource.URI,
 						password:    "",
 						description: resource.Description,
+						metadataFields: map[string]any{
+							"name":        resource.Name,
+							"username":    resource.Username,
+							"uri":         resource.URI,
+							"description": resource.Description,
+						},
 					}
 					continue
 				}
@@ -198,7 +204,7 @@ func decryptResourcesParallel(ctx context.Context, client *api.Client, resources
 					secret = resource.Secrets[0]
 				}
 
-				_, name, username, uri, pass, desc, err := helper.GetResourceFromDataWithOptions(
+				_, name, username, uri, pass, desc, metaFields, secFields, err := helper.GetResourceFieldMaps(
 					client,
 					resource,
 					secret,
@@ -206,14 +212,16 @@ func decryptResourcesParallel(ctx context.Context, client *api.Client, resources
 					needSecrets,
 				)
 				results <- decryptedResource{
-					index:       idx,
-					resource:    resource,
-					name:        name,
-					username:    username,
-					uri:         uri,
-					password:    pass,
-					description: desc,
-					err:         err,
+					index:          idx,
+					resource:       resource,
+					name:           name,
+					username:       username,
+					uri:            uri,
+					password:       pass,
+					description:    desc,
+					metadataFields: metaFields,
+					secretFields:   secFields,
+					err:            err,
 				}
 			}
 		}()

--- a/resource/update.go
+++ b/resource/update.go
@@ -24,21 +24,48 @@ func init() {
 	ResourceUpdateCmd.Flags().StringP("password", "p", "", "Resource Password")
 	ResourceUpdateCmd.Flags().StringP("description", "d", "", "Resource Description")
 	ResourceUpdateCmd.Flags().String("expiry", "", "Expiry as RFC3339 (e.g. 2025-12-31T23:59:59Z), duration (e.g. 7d, 12h), or 'none' to clear")
-	ResourceUpdateCmd.Flags().StringArray("field", []string{}, "Metadata field as key=value (repeatable)")
-	ResourceUpdateCmd.Flags().StringArray("secret-field", []string{}, "Secret field as key=value (repeatable)")
+	ResourceUpdateCmd.Flags().StringArray("field", []string{}, "Metadata field as key=value (repeatable; JSON values like [\"a\"] are parsed automatically)")
+	ResourceUpdateCmd.Flags().StringArray("secret-field", []string{}, "Secret field as key=value (repeatable; JSON values are parsed automatically)")
 	ResourceUpdateCmd.MarkFlagRequired("id")
 }
 
 func ResourceUpdate(cmd *cobra.Command, args []string) error {
-	id, _ := cmd.Flags().GetString("id")
-	name, _ := cmd.Flags().GetString("name")
-	username, _ := cmd.Flags().GetString("username")
-	uri, _ := cmd.Flags().GetString("uri")
-	password, _ := cmd.Flags().GetString("password")
-	description, _ := cmd.Flags().GetString("description")
-	expiry, _ := cmd.Flags().GetString("expiry")
-	fields, _ := cmd.Flags().GetStringArray("field")
-	secretFields, _ := cmd.Flags().GetStringArray("secret-field")
+	id, err := cmd.Flags().GetString("id")
+	if err != nil {
+		return err
+	}
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+	username, err := cmd.Flags().GetString("username")
+	if err != nil {
+		return err
+	}
+	uri, err := cmd.Flags().GetString("uri")
+	if err != nil {
+		return err
+	}
+	password, err := cmd.Flags().GetString("password")
+	if err != nil {
+		return err
+	}
+	description, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return err
+	}
+	expiry, err := cmd.Flags().GetString("expiry")
+	if err != nil {
+		return err
+	}
+	fields, err := cmd.Flags().GetStringArray("field")
+	if err != nil {
+		return err
+	}
+	secretFields, err := cmd.Flags().GetStringArray("secret-field")
+	if err != nil {
+		return err
+	}
 
 	useGeneric := len(fields) > 0 || len(secretFields) > 0
 
@@ -64,16 +91,7 @@ func ResourceUpdate(cmd *cobra.Command, args []string) error {
 			metadataUpdates["username"] = username
 		}
 		if uri != "" {
-			// Fetch the resource to determine if v5 (needs "uris") or v4 (needs "uri")
-			resource, fetchErr := client.GetResource(ctx, id)
-			if fetchErr != nil {
-				return fmt.Errorf("getting resource: %w", fetchErr)
-			}
-			if resource.Metadata != "" {
-				metadataUpdates["uris"] = []string{uri}
-			} else {
-				metadataUpdates["uri"] = uri
-			}
+			metadataUpdates["uri"] = uri
 		}
 		if description != "" {
 			metadataUpdates["description"] = description

--- a/resource/update.go
+++ b/resource/update.go
@@ -24,39 +24,23 @@ func init() {
 	ResourceUpdateCmd.Flags().StringP("password", "p", "", "Resource Password")
 	ResourceUpdateCmd.Flags().StringP("description", "d", "", "Resource Description")
 	ResourceUpdateCmd.Flags().String("expiry", "", "Expiry as RFC3339 (e.g. 2025-12-31T23:59:59Z), duration (e.g. 7d, 12h), or 'none' to clear")
+	ResourceUpdateCmd.Flags().StringArray("field", []string{}, "Metadata field as key=value (repeatable)")
+	ResourceUpdateCmd.Flags().StringArray("secret-field", []string{}, "Secret field as key=value (repeatable)")
 	ResourceUpdateCmd.MarkFlagRequired("id")
 }
 
 func ResourceUpdate(cmd *cobra.Command, args []string) error {
-	id, err := cmd.Flags().GetString("id")
-	if err != nil {
-		return err
-	}
-	name, err := cmd.Flags().GetString("name")
-	if err != nil {
-		return err
-	}
-	username, err := cmd.Flags().GetString("username")
-	if err != nil {
-		return err
-	}
-	uri, err := cmd.Flags().GetString("uri")
-	if err != nil {
-		return err
-	}
-	password, err := cmd.Flags().GetString("password")
-	if err != nil {
-		return err
-	}
-	description, err := cmd.Flags().GetString("description")
-	if err != nil {
-		return err
-	}
+	id, _ := cmd.Flags().GetString("id")
+	name, _ := cmd.Flags().GetString("name")
+	username, _ := cmd.Flags().GetString("username")
+	uri, _ := cmd.Flags().GetString("uri")
+	password, _ := cmd.Flags().GetString("password")
+	description, _ := cmd.Flags().GetString("description")
+	expiry, _ := cmd.Flags().GetString("expiry")
+	fields, _ := cmd.Flags().GetStringArray("field")
+	secretFields, _ := cmd.Flags().GetStringArray("secret-field")
 
-	expiry, err := cmd.Flags().GetString("expiry")
-	if err != nil {
-		return err
-	}
+	useGeneric := len(fields) > 0 || len(secretFields) > 0
 
 	ctx, cancel := util.GetContext()
 	defer cancel()
@@ -68,18 +52,58 @@ func ResourceUpdate(cmd *cobra.Command, args []string) error {
 	defer util.SaveSessionKeysAndLogout(ctx, client)
 	cmd.SilenceUsage = true
 
-	err = helper.UpdateResource(
-		ctx,
-		client,
-		id,
-		name,
-		username,
-		uri,
-		password,
-		description,
-	)
+	if useGeneric {
+		// Generic path: use UpdateResourceGeneric with field maps
+		metadataUpdates := map[string]any{}
+		secretUpdates := map[string]any{}
+
+		if name != "" {
+			metadataUpdates["name"] = name
+		}
+		if username != "" {
+			metadataUpdates["username"] = username
+		}
+		if uri != "" {
+			// Fetch the resource to determine if v5 (needs "uris") or v4 (needs "uri")
+			resource, fetchErr := client.GetResource(ctx, id)
+			if fetchErr != nil {
+				return fmt.Errorf("getting resource: %w", fetchErr)
+			}
+			if resource.Metadata != "" {
+				metadataUpdates["uris"] = []string{uri}
+			} else {
+				metadataUpdates["uri"] = uri
+			}
+		}
+		if description != "" {
+			metadataUpdates["description"] = description
+		}
+		if password != "" {
+			secretUpdates["password"] = password
+		}
+
+		for _, f := range fields {
+			k, v, parseErr := parseKeyValue(f)
+			if parseErr != nil {
+				return fmt.Errorf("invalid --field: %w", parseErr)
+			}
+			metadataUpdates[k] = v
+		}
+		for _, f := range secretFields {
+			k, v, parseErr := parseKeyValue(f)
+			if parseErr != nil {
+				return fmt.Errorf("invalid --secret-field: %w", parseErr)
+			}
+			secretUpdates[k] = v
+		}
+
+		err = helper.UpdateResourceGeneric(ctx, client, id, metadataUpdates, secretUpdates)
+	} else {
+		err = helper.UpdateResource(ctx, client, id, name, username, uri, password, description)
+	}
+
 	if err != nil {
-		return fmt.Errorf("updating Resource: %w", err)
+		return fmt.Errorf("updating resource: %w", err)
 	}
 
 	if expiry != "" {


### PR DESCRIPTION
**Summary**

- Add `--type`, `--field key=value`, and `--secret-field key=value` flags to
  `create` and `update` commands for working with any resource type
- Use the new `Resource` wrapper in `get` for dynamic field output
  (including custom fields in JSON mode)
- Add `Metadata` and `Secret` map variables to CEL filter environment
- Migrate keepass export from type-specific structs to schema-driven
  TOTP extraction
- JSON output now includes full `metadata` and `secret` maps

Depends on passbolt/go-passbolt#67 (schema-driven resource type support).

**Examples**

```sh
Create a v5-custom-fields resource:
passbolt create resource --type v5-custom-fields \
  --name "CI Config" \
  --field custom_fields='[{"id":"1","type":"text","metadata_key":"env","metadata_value":"prod"}]' \
  --secret-field custom_fields='[{"id":"1","type":"password","secret_key":"token","secret_value":"s3cret"}]'

Update a custom field:
passbolt update resource --id <uuid>  --secret-field api_key=newsecret

Filter on metadata map in list:
passbolt list resource --filter 'Metadata.name == "CI Config"'
```
Signed-off-by: Cédric HERZOG <cedric.herzog@passbolt.com>